### PR TITLE
23 - Team

### DIFF
--- a/strapi/src/api/index/content-types/index/schema.json
+++ b/strapi/src/api/index/content-types/index/schema.json
@@ -20,7 +20,9 @@
       "type": "media",
       "multiple": true,
       "required": false,
-      "allowedTypes": ["images"],
+      "allowedTypes": [
+        "images"
+      ],
       "pluginOptions": {
         "i18n": {
           "localized": true
@@ -62,14 +64,15 @@
       },
       "type": "text"
     },
-    "blocks": {
+    "team": {
+      "type": "component",
+      "repeatable": false,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "type": "dynamiczone",
-      "components": []
+      "component": "project.team"
     }
   }
 }

--- a/strapi/src/api/index/content-types/index/schema.json
+++ b/strapi/src/api/index/content-types/index/schema.json
@@ -20,9 +20,7 @@
       "type": "media",
       "multiple": true,
       "required": false,
-      "allowedTypes": [
-        "images"
-      ],
+      "allowedTypes": ["images"],
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/strapi/src/components/project/team-leadership.json
+++ b/strapi/src/components/project/team-leadership.json
@@ -1,0 +1,15 @@
+{
+  "collectionName": "components_project_team_leaderships",
+  "info": {
+    "displayName": "Team Leadership"
+  },
+  "options": {},
+  "attributes": {
+    "role": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/project/team.json
+++ b/strapi/src/components/project/team.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_project_teams",
+  "info": {
+    "displayName": "Team",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "teamPhoto": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "teamLeadership": {
+      "type": "component",
+      "repeatable": true,
+      "component": "project.team-leadership"
+    },
+    "name": {
+      "type": "string",
+      "unique": false,
+      "required": true
+    }
+  }
+}

--- a/strapi/src/components/project/team.json
+++ b/strapi/src/components/project/team.json
@@ -10,9 +10,7 @@
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": [
-        "images"
-      ]
+      "allowedTypes": ["images"]
     },
     "teamLeadership": {
       "type": "component",

--- a/web/.netlify/deploy/v1/config.json
+++ b/web/.netlify/deploy/v1/config.json
@@ -1,5 +1,1 @@
-{
-  "images": {
-    "remote_images": ["https?://wdcc-website\\.fly\\.storage\\.tigris\\.dev/.*"]
-  }
-}
+{"images":{"remote_images":["https?://wdcc-website\\.fly\\.storage\\.tigris\\.dev/.*"]}}

--- a/web/.netlify/deploy/v1/config.json
+++ b/web/.netlify/deploy/v1/config.json
@@ -1,1 +1,5 @@
-{"images":{"remote_images":["https?://wdcc-website\\.fly\\.storage\\.tigris\\.dev/.*"]}}
+{
+  "images": {
+    "remote_images": ["https?://wdcc-website\\.fly\\.storage\\.tigris\\.dev/.*"]
+  }
+}

--- a/web/src/components/projects/ProjectTeam.tsx
+++ b/web/src/components/projects/ProjectTeam.tsx
@@ -1,0 +1,43 @@
+interface Team {
+  role?: string;
+  name: string;
+}
+
+interface ProjectTeamProps {
+  team: Team[];
+  teamImg?: {
+    src: string;
+    alt: string;
+  } | null;
+}
+
+const ProjectTeam = ({ team, teamImg }: ProjectTeamProps) => {
+  return (
+    <div className="flex flex-col md:flex-row my-8">
+      <div className="basis-1/2 p-4">
+        <h4>Team Leadership</h4>
+        <hr className="border-t-2 border-gray-500 my-4 w-[1.25rem]" />
+        <ul className="list-inside list-disc">
+          {team.map((teamMember, index) => (
+            <li key={index} className="mb-2">
+              {teamMember.role && (
+                <>
+                  <strong>{teamMember.role}</strong>
+                  <span className="font-normal"> - </span>
+                </>
+              )}
+              {teamMember.name}
+            </li>
+          ))}
+        </ul>
+      </div>
+      {teamImg && (
+        <div className="basis-1/2 flex items-center justify-center">
+          <img src={teamImg.src} alt={teamImg.alt} className="rounded-lg" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProjectTeam;

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -33,7 +33,6 @@ const teamImg = teamPhotoResponse
       alt: teamPhotoResponse.attributes.alternativeText,
     }
   : null;
-
 ---
 
 <Layout

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Hero from "@/components/home/Hero";
+import ProjectTeam from "@/components/projects/ProjectTeam";
 import "@/global.css";
 import Layout from "../layouts/layout.astro";
 import fetchApi from "../lib/strapi";
@@ -18,6 +19,21 @@ const imageUrl =
 const imageAlt = index.attributes.gallery.data[0].attributes.alternativeText;
 const linkHref = index.attributes.links[0].href;
 const linkText = index.attributes.links[0].value;
+
+const team = await await fetchApi<any>({
+  endpoint: "index?populate[team][populate]=*",
+  wrappedByKey: "data",
+});
+
+const teamMembers = team.attributes.team.teamLeadership;
+const teamPhotoResponse = team.attributes.team.teamPhoto?.data;
+const teamImg = teamPhotoResponse
+  ? {
+      src: STRAPI_URL + teamPhotoResponse.attributes.formats.large.url,
+      alt: teamPhotoResponse.attributes.alternativeText,
+    }
+  : null;
+
 ---
 
 <Layout
@@ -33,5 +49,6 @@ const linkText = index.attributes.links[0].value;
       linkHref={linkHref}
       linkText={linkText}
     />
+    <ProjectTeam team={teamMembers} teamImg={teamImg} />
   </div>
 </Layout>


### PR DESCRIPTION
## Context
This change is being made to ensure that all team members' contributions to the WDCC projects are properly credited on the project's details page.

Closes #23 

## What Changed?
1. Created ProjectTeam component `web/src/components/projects/ProjectTeam.tsx`

## How To Review
1. Spin up `strapi` and `web`
2. Navigate to the home directory to see the example usage of the `ProjectTeam` component.
3. Verify that the component is displayed correctly and data is populated as expected.

## Testing

1. Created a dummy team in Strapi
2. Navigated to `localhost:4321/` and ensured data from Strapi is populated correctly
3. Manually tested responsiveness of component across different screen sizes.

## Notes
- An example usage of the `ProjectTeam` component has been added to our homepage to demonstrate its functionality.
This can be moved once the `Projects` page has been implemented.
Once `Projects` page is live, the component will need to be refactored to dynamically fetch and populate the team member data and images relevant to each project.