### PR TITLE
Project Requirements

### DIFF
--- a/strapi/src/api/project-requirement/content-types/project-requirement/schema.json
+++ b/strapi/src/api/project-requirement/content-types/project-requirement/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "collectionType",
+  "collectionName": "project_requirements",
+  "info": {
+    "singularName": "project-requirement",
+    "pluralName": "project-requirements",
+    "displayName": "Project Requirement"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Description": {
+      "type": "blocks"
+    },
+    "Title": {
+      "type": "string"
+    },
+    "Demo": {
+      "allowedTypes": [
+        "images",
+        "videos"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/strapi/src/api/project-requirement/content-types/project-requirement/schema.json
+++ b/strapi/src/api/project-requirement/content-types/project-requirement/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "project-requirement",
     "pluralName": "project-requirements",
-    "displayName": "Project Requirement"
+    "displayName": "Project Requirement",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -12,18 +13,21 @@
   "pluginOptions": {},
   "attributes": {
     "Description": {
-      "type": "blocks"
+      "type": "blocks",
+      "required": true
     },
     "Title": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "Demo": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
       "allowedTypes": [
         "images",
         "videos"
-      ],
-      "type": "media",
-      "multiple": false
+      ]
     }
   }
 }

--- a/strapi/src/api/project-requirement/controllers/project-requirement.ts
+++ b/strapi/src/api/project-requirement/controllers/project-requirement.ts
@@ -1,0 +1,7 @@
+/**
+ * project-requirement controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::project-requirement.project-requirement');

--- a/strapi/src/api/project-requirement/routes/project-requirement.ts
+++ b/strapi/src/api/project-requirement/routes/project-requirement.ts
@@ -1,0 +1,7 @@
+/**
+ * project-requirement router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::project-requirement.project-requirement');

--- a/strapi/src/api/project-requirement/services/project-requirement.ts
+++ b/strapi/src/api/project-requirement/services/project-requirement.ts
@@ -1,0 +1,7 @@
+/**
+ * project-requirement service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::project-requirement.project-requirement');


### PR DESCRIPTION
## Context

<!-- Include contextual info that can't be found in the linked issue. Why are you making this change? -->
I have finished this ticket only by making the backend Strapi type for the project requirements. There is no frontend implementation yet, because we want to implement the front end through the Project Details type coming up in a future ticket.
This will remove the need for making redundant code, as the whole Project Details Strapi type is necessary to get each section of the Project Details page.

This Project Requirements Type will be used in the Project Details type, then from there, we can code up the HTML for the Requirements section of the Project Details.  This change will allow us to display one or multiple project requirements associated with each project in the project details page. Flexibility is important for future WDCC Execs who will be changing the content of the website, so I believe this will be a vital change for future-proofing. Overall, this allows site visitors to clearly see the problems and intricacies involved with making WDCC projects.

## What Changed?

<!-- What changes did you make? -->
Just added a project requirement type via Strapi, which has three parts:
- Title: A description of the requirement in a few words 
- Description: Detailed list or paragraph of the sub-requirements
- Image: Optional image or video showcasing the requirement in action

## How To Review

<!-- What (rough) order should the reviewer view your files? Where should they focus? -->
Just check that you are able to add project requirements via Strapi. Make sure to add a title and description.

## Testing

<!-- What testing did you do, if any? Any risks? -->
N/A

## Notes

Would love to be merged, so that we can start using this type in actually displaying the project details. 