### PR TITLE
adding strapi to the events summary

### DIFF
--- a/strapi/src/api/event/content-types/event/schema.json
+++ b/strapi/src/api/event/content-types/event/schema.json
@@ -1,0 +1,19 @@
+{
+  "kind": "singleType",
+  "collectionName": "events",
+  "info": {
+    "singularName": "event",
+    "pluralName": "events",
+    "displayName": "Events",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "summary": {
+      "type": "text"
+    }
+  }
+}

--- a/strapi/src/api/event/controllers/event.ts
+++ b/strapi/src/api/event/controllers/event.ts
@@ -1,0 +1,7 @@
+/**
+ * event controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::event.event');

--- a/strapi/src/api/event/routes/event.ts
+++ b/strapi/src/api/event/routes/event.ts
@@ -1,0 +1,7 @@
+/**
+ * event router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::event.event');

--- a/strapi/src/api/event/services/event.ts
+++ b/strapi/src/api/event/services/event.ts
@@ -1,0 +1,7 @@
+/**
+ * event service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::event.event');

--- a/web/src/pages/events/index.astro
+++ b/web/src/pages/events/index.astro
@@ -1,14 +1,20 @@
 ---
 import Layout from "@/layouts/layout.astro";
+import fetchApi from "../../lib/strapi";
+
+const eventsSummary = await fetchApi<any>({
+  endpoint: "event?populate=*",
+  wrappedByKey: "data",
+});
+
+const summary = eventsSummary.attributes.summary;
 ---
 
 <Layout title="Events" description="Upcoming events at WDCC">
   <section class="py-16 text-center">
     <h1 class="text-4xl font-bold mb-4">Upcoming Events</h1>
-    <p class="text-lg text-gray-600 max-w-5xl mx-auto">
-      WDCC hosts regular workshops, competitions and social events throughout the year.
-      We aim to help students develop practical skills that can be used in the workforce.
-      We host social events to help students network among peers and with industry people.
-    </p>
+    <div class="container">
+      <p class="text-lg">{summary}</p>
+    </div>
   </section>
 </Layout>


### PR DESCRIPTION
## Context

This change is being made so that in the future, it is easier to update summary on strapi

Closes #45 

## What Changed?

changed hard coded summary to strapi

## How To Review

Add random text to strapi content manager for events and test
Check out pages/events/index.astro

## Testing



## Notes
